### PR TITLE
Set ESSR registers when initializing ht32 pal_lld

### DIFF
--- a/os/hal/ports/HT32/LLD/hal_pal_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_pal_lld.c
@@ -85,6 +85,8 @@ void _pal_lld_init(const PALConfig *config) {
     for (size_t i = 0; i < HT32_NUM_GPIO; i++) {
         initgpio(HT32_PAL_ID(i), &(config->setup[i]));
     }
+    AFIO->ESSR[0] = config->ESSR[0];
+    AFIO->ESSR[1] = config->ESSR[1];
 }
 
 /**


### PR DESCRIPTION
The values to those registers were already in the config structure, but unused.