### PR TITLE
ht32 usb assertion fixes

### DIFF
--- a/os/hal/ports/HT32/LLD/hal_usb_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_usb_lld.c
@@ -442,6 +442,7 @@ void usb_lld_reset(USBDriver *usbp) {
     // USB Reset
     // Clear CSR, except for DP pull up
     USB->CSR &= USBCSR_DPPUEN;
+    USB->DEVAR = 0;
 
     /* Post reset initialization.*/
     usbp->epmem_next = 8;
@@ -463,7 +464,6 @@ void usb_lld_reset(USBDriver *usbp) {
  * @notapi
  */
 void usb_lld_set_address(USBDriver *usbp) {
-    USB->CSR |= USBCSR_ADRSET;
     USB->DEVAR = usbp->address & 0x7f;
 }
 

--- a/os/hal/ports/HT32/LLD/hal_usb_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_usb_lld.c
@@ -219,87 +219,28 @@ OSAL_IRQ_HANDLER(HT32_USB_IRQ_VECTOR) {
         usb_clear_int_flags(USBISR_RSMIF);
     }
 
-    // EP0 Interrupt
-    if(isr & USBISR_EP0IF){
-        uint32_t episr = usb_get_ep_int_flags(0);
-
-#if 0
-        // SETUP Token Received
-        if(episr & USBEPnISR_STRXIF){
-            usb_clear_ep_int_flags(0, USBEPnISR_STRXIF);
-        }
-#endif
-
-        // SETUP Data Received
-        if(episr & USBEPnISR_SDRXIF){
-            // SETUP callback
-            _usb_isr_invoke_setup_cb(usbp, 0);
-            usb_clear_ep_int_flags(0, USBEPnISR_SDRXIF);
-        }
-
-#if 0
-        // OUT Token Received
-        if(episr & USBEPnISR_OTRXIF){
-            usb_clear_ep_int_flags(0, USBEPnISR_OTRXIF);
-        }
-#endif
-
-        // OUT Data Received
-        if(episr & USBEPnISR_ODRXIF){
-            USBOutEndpointState *osp = usbp->epc[0]->out_state;
-            size_t n = usb_packet_receive(usbp, 0);
-            if ((n < usbp->epc[0]->out_maxsize) || (osp->rxpkts == 0)) {
-                // OUT callback
-                _usb_isr_invoke_out_cb(usbp, 0);
-            } else {
-                USB->EP[0].CSR &= USBEPnCSR_NAKRX;
-            }
-            usb_clear_ep_int_flags(0, USBEPnISR_ODRXIF);
-        }
-
-#if 0
-        // IN Token Received
-        if(episr & USBEPnISR_ITRXIF){
-            usb_clear_ep_int_flags(0, USBEPnISR_ITRXIF);
-        }
-#endif
-
-        // IN Data Transmitted
-        if(episr & USBEPnISR_IDTXIF){
-            USBInEndpointState *isp = usbp->epc[0]->in_state;
-            size_t n = isp->txlastpktlen;
-            isp->txcnt += n;
-            if (isp->txcnt < isp->txsize) {
-                isp->txbuf += n;
-                osalSysLockFromISR();
-                usb_packet_transmit(usbp, 0, isp->txsize - isp->txcnt);
-                osalSysUnlockFromISR();
-            } else {
-                // IN callback
-                _usb_isr_invoke_in_cb(usbp, 0);
-            }
-            usb_clear_ep_int_flags(0, USBEPnISR_IDTXIF);
-        }
-
-#if 0
-        // STALL Transmitted
-        if(episr & USBEPnISR_STLIF){
-            usb_clear_ep_int_flags(0, USBEPnISR_STLIF);
-        }
-#endif
-
-        usb_clear_int_flags(USBISR_EP0IF);
-    }
-
-    // EP 1-7 Interrupt
-    uint32_t mask = USBISR_EP1IF;
-    for(int i = 1; i < 8; ++i){
+    // EP 0-7 Interrupt
+    uint32_t mask = USBISR_EP0IF;
+    for(int i = 0; i < 8; ++i){
         // EPn Interrupt
         if(isr & mask){
             uint32_t episr = usb_get_ep_int_flags(i);
 
             usb_clear_ep_int_flags(i, episr);
             usb_clear_int_flags(mask);
+
+#if 0
+            // SETUP Token Received
+            if(episr & USBEPnISR_STRXIF){
+              usb_clear_ep_int_flags(i, USBEPnISR_STRXIF);
+            }
+#endif
+
+            // SETUP Data Received
+            if(episr & USBEPnISR_SDRXIF){
+              // SETUP callback
+              _usb_isr_invoke_setup_cb(usbp, i);
+            }
 
 #if 0
             // IN Token Received

--- a/os/hal/ports/HT32/LLD/hal_usb_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_usb_lld.c
@@ -229,6 +229,11 @@ OSAL_IRQ_HANDLER(HT32_USB_IRQ_VECTOR) {
             usb_clear_ep_int_flags(i, episr);
             usb_clear_int_flags(mask);
 
+            if ((isr & USBISR_URSTIF)
+                || (usbp->epc[i] == NULL)) {
+              mask = mask << 1;
+              continue;
+            }
 #if 0
             // SETUP Token Received
             if(episr & USBEPnISR_STRXIF){

--- a/os/hal/ports/HT32/LLD/hal_usb_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_usb_lld.c
@@ -302,25 +302,6 @@ OSAL_IRQ_HANDLER(HT32_USB_IRQ_VECTOR) {
             usb_clear_int_flags(mask);
 
 #if 0
-            // OUT Token Received
-            if(episr & USBEPnISR_OTRXIF){
-                usb_clear_ep_int_flags(i, USBEPnISR_OTRXIF);
-            }
-#endif
-
-            // OUT Data Received
-            if(episr & USBEPnISR_ODRXIF){
-                USBOutEndpointState *osp = usbp->epc[i]->out_state;
-                size_t n = usb_packet_receive(usbp, i);
-                if ((n < usbp->epc[i]->out_maxsize) || (osp->rxpkts == 0)) {
-                    // OUT callback
-                    _usb_isr_invoke_out_cb(usbp, i);
-                } else {
-                    USB->EP[i].CSR &= USBEPnCSR_NAKRX;
-                }
-            }
-
-#if 0
             // IN Token Received
             if(episr & USBEPnISR_ITRXIF){
                 usb_clear_ep_int_flags(i, USBEPnISR_ITRXIF);
@@ -340,6 +321,25 @@ OSAL_IRQ_HANDLER(HT32_USB_IRQ_VECTOR) {
                 } else {
                     // IN callback
                     _usb_isr_invoke_in_cb(usbp, i);
+                }
+            }
+
+#if 0
+            // OUT Token Received
+            if(episr & USBEPnISR_OTRXIF){
+                usb_clear_ep_int_flags(i, USBEPnISR_OTRXIF);
+            }
+#endif
+
+            // OUT Data Received
+            if(episr & USBEPnISR_ODRXIF){
+                USBOutEndpointState *osp = usbp->epc[i]->out_state;
+                size_t n = usb_packet_receive(usbp, i);
+                if ((n < usbp->epc[i]->out_maxsize) || (osp->rxpkts == 0)) {
+                    // OUT callback
+                    _usb_isr_invoke_out_cb(usbp, i);
+                } else {
+                    USB->EP[i].CSR &= USBEPnCSR_NAKRX;
                 }
             }
 

--- a/os/hal/ports/HT32/LLD/hal_usb_lld.h
+++ b/os/hal/ports/HT32/LLD/hal_usb_lld.h
@@ -45,7 +45,7 @@
 /**
  * @brief   The address can be changed immediately upon packet reception.
  */
-#define USB_SET_ADDRESS_MODE                USB_EARLY_SET_ADDRESS
+#define USB_SET_ADDRESS_MODE                USB_LATE_SET_ADDRESS
 
 /**
  * @brief   Method for set address acknowledge.


### PR DESCRIPTION
Without those changes i got some usb assertions when running with an AHB clock frequncy of 24MHz on my main development machine.

It seems like endpoint events should be ignored if there was also a reset event, otherwise the next "real" endpoint event will lead to an "already transmitting/receiving" assertion.

Except for the setup packet handling, the ep0 endpoint is identical, so i moved the setup handling also to the handling for all endpoints.

The late address set mode worked better for me, otherwise i did get one dmesg line on FreeBSD or Linux.

By handling the usb in interrupts first,  some usb assertions (wrong ep0 state) were gone as well.