### PR TITLE
Fix configuration for HT32_AHB_PRESCALER

### DIFF
--- a/os/hal/ports/HT32/LLD/hal_lld.c
+++ b/os/hal/ports/HT32/LLD/hal_lld.c
@@ -83,7 +83,15 @@ void ht32_clock_init(void) {
 #endif
 
     // AHB prescaler
+#if HT32_AHB_PRESCALER == 1 || HT32_AHB_PRESCALER == 2
     CKCU->AHBCFGR = (CKCU->AHBCFGR & ~CKCU_AHBCFGR_AHBPRE_MASK) | (HT32_AHB_PRESCALER - 1);
+#elif HT32_AHB_PRESCALER == 4
+    CKCU->AHBCFGR = (CKCU->AHBCFGR & ~CKCU_AHBCFGR_AHBPRE_MASK) | (2);
+#elif HT32_AHB_PRESCALER == 8
+    CKCU->AHBCFGR = (CKCU->AHBCFGR & ~CKCU_AHBCFGR_AHBPRE_MASK) | (3);
+#else
+#error "Invalid AHB_PRESCALER value"
+#endif
 
     // Clock switch
     CKCU->GCCR = (CKCU->GCCR & ~CKCU_GCCR_SW_MASK) | HT32_CKCU_SW;

--- a/os/hal/ports/HT32/LLD/hal_lld.h
+++ b/os/hal/ports/HT32/LLD/hal_lld.h
@@ -99,7 +99,7 @@
 #endif
 
 #if !defined(HT32_AHB_PRESCALER)
-    #define HT32_AHB_PRESCLAER 1
+    #define HT32_AHB_PRESCALER 1
 #endif
 
 // AHB clock


### PR DESCRIPTION
The default value had a typo and the register value was only correct for the AHB Prescaler of 1 or 2.